### PR TITLE
add a lock around writing to / reading from seqno to prevent data races

### DIFF
--- a/vcr.go
+++ b/vcr.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 )
 
 // Mode is used to signify the current operating mode of VCR.
@@ -34,6 +35,7 @@ var (
 
 // VCR is an http client that can record and playback responses to http requests.
 type VCR struct {
+	sync.Mutex
 	dir   string
 	mode  mode
 	seqno map[string]int
@@ -153,6 +155,8 @@ func (v *VCR) PostForm(url string, data url.Values) (resp *http.Response, err er
 }
 
 func (v *VCR) incSeqno(hash string) {
+	v.Lock()
+	defer v.Unlock()
 	v.seqno[hash]++
 }
 
@@ -237,6 +241,8 @@ func (v *VCR) postFormFilename(url string, data url.Values) (string, string, err
 }
 
 func (v *VCR) filename(prefix, hash string) string {
+	v.Lock()
+	defer v.Unlock()
 	return filepath.Join(v.dir, fmt.Sprintf("%s_%s_%d.vcr", prefix, hash, v.seqno[hash]))
 }
 


### PR DESCRIPTION
![Screen Shot 2019-10-17 at 10 26 57 AM](https://user-images.githubusercontent.com/1275828/67018066-ab534f80-f0c8-11e9-9bd0-f249c0130766.png)

makes this pass